### PR TITLE
Force enable containerregistry.googleapis.com

### DIFF
--- a/falcon-container-terraform/run
+++ b/falcon-container-terraform/run
@@ -37,6 +37,7 @@ if [ -z "$(gcloud config get-value project 2> /dev/null)" ]; then
    fi
 fi
 export TF_VAR_project_id=$(gcloud config get-value project 2> /dev/null)
+gcloud services enable containerregistry.googleapis.com
 
 
 [ -d ~/cloud-gcp ] || (cd "$HOME" && git clone --depth 1 https://github.com/crowdstrike/cloud-gcp)


### PR DESCRIPTION
Addressing:
```
╷
│ Error: googleapi: got HTTP response code 400 with body: {"errors":[{"code":"UNKNOWN","message":"Service 'containerregistry.googleapis.com' is not enabled for consumer 'project:pr-0tieyzkmky4qy'."}]}
│
│   with google_container_registry.registry,
│   on gcr.tf line 1, in resource "google_container_registry" "registry":
│    1: resource "google_container_registry" "registry" {
│
```

/cc @ssumner32