### PR TITLE
updated for latest walkthrough

### DIFF
--- a/container/falcon-container-terraform/gke-admin-vm.sh.tpl
+++ b/container/falcon-container-terraform/gke-admin-vm.sh.tpl
@@ -141,7 +141,7 @@ detection_uri(){
     echo "  # to get all running pods on the cluster"
     echo "  sudo kubectl get pods --all-namespaces"
     echo "  # to get Falcon agent/host ID of vulnerable.example.com"
-    echo "  sudo kubectl exec deploy/vulnerable.example.com -c falcon-container -- falconctl -g --aid"
+    echo "  sudo kubectl exec deploy/vulnerable.example.com -c crowdstrike-falcon-container -- falconctl -g --aid"
     echo "  # to view Falcon injector logs"
     echo "  sudo kubectl logs -n falcon-system deploy/injector"
     echo "  # to uninstall the vulnerable.example.com"

--- a/container/falcon-container-terraform/run
+++ b/container/falcon-container-terraform/run
@@ -41,7 +41,7 @@ gcloud services enable containerregistry.googleapis.com
 
 
 [ -d ~/cloud-gcp ] || (cd "$HOME" && git clone --depth 1 https://github.com/crowdstrike/cloud-gcp)
-[ -d ~/falcon-container-terraform ] || (ln -s $HOME/cloud-gcp/falcon-container-terraform $HOME/falcon-container-terraform)
+[ -d ~/falcon-container-terraform ] || (ln -s $HOME/cloud-gcp/container/falcon-container-terraform $HOME/falcon-container-terraform)
 cd ~/falcon-container-terraform
 terraform init
 

--- a/container/falcon-container-terraform/versions.tf
+++ b/container/falcon-container-terraform/versions.tf
@@ -6,6 +6,6 @@ terraform {
     }
   }
 
-  required_version = "~> 0.12"
+  required_version = "~> 1.0"
 }
 


### PR DESCRIPTION
updated TF version as Cloud-Shell uses 1.0 now and the ~>0.12 does not work in versions.tf. Updated Paths and container name as well. This was tested in GCP Cloud-Shell.